### PR TITLE
(fix) Fix mix_tests to use :null instead of nil

### DIFF
--- a/bench/decode.exs
+++ b/bench/decode.exs
@@ -5,7 +5,7 @@ decode_jobs = %{
   "JSX" => fn {json, _} -> JSX.decode!(json, [:strict]) end,
   "Tiny" => fn {json, _} -> Tiny.decode!(json) end,
   "jsone" => fn {json, _} -> :jsone.decode(json) end,
-  # "jiffy" => fn {json, _} -> :jiffy.decode(json, [:return_maps, :use_nil]) end,
+  "jiffy" => fn {json, _} -> :jiffy.decode(json, [:return_maps]) end,
   "JSON" => fn {json, _} -> JSON.decode!(json) end
   # "binary_to_term/1" => fn {_, etf} -> :erlang.binary_to_term(etf) end,
 }

--- a/mix_tests/test/encode_test.exs
+++ b/mix_tests/test/encode_test.exs
@@ -2,7 +2,7 @@ defmodule Jason.EncoderTest do
   use ExUnit.Case, async: true
 
   test "atom" do
-    assert to_json(nil) == "null"
+    assert to_json(:null) == "null"
     assert to_json(true) == "true"
     assert to_json(false) == "false"
     assert to_json(:poison) == ~s("poison")

--- a/mix_tests/test/property_test.exs
+++ b/mix_tests/test/property_test.exs
@@ -52,7 +52,7 @@ if Code.ensure_loaded?(ExUnitProperties) do
     end
 
     defp json(keys) do
-      simple = one_of([integer(), float(), string(:printable), boolean(), nil])
+      simple = one_of([integer(), float(), string(:printable), boolean(), :null])
 
       tree(simple, fn json ->
         one_of([list_of(json), map_of(keys, json)])


### PR DESCRIPTION
Fix the mix_tests to use null atom instead of Elixir nil