### PR TITLE
Add property-based tests (some are failing)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,11 @@ jobs:
           otp-version: "24.2"
           elixir-version: "1.13.1"
 
-      - run: rebar3 eunit
+      - run: rebar3 eunit -c
+
+      - run: rebar3 proper -c
+
+      - run: rebar3 cover -v -m 50  # min 50% rebar3-based test coverage
 
       - run: mix deps.get
         working-directory: mix_tests

--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,5 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
+{project_plugins, [rebar3_proper]}.
+
+{profiles, [{test, [{deps, [{proper, "1.4.0"}, {jsx, "3.1.0"}]}]}]}.

--- a/src/thoas.erl
+++ b/src/thoas.erl
@@ -19,6 +19,7 @@
 }.
 
 -type json_term() :: 
+    null |
     integer() |
     float() |
     binary() |
@@ -26,12 +27,12 @@
     #{ binary() => json_term() }.
 
 -type input_term() :: 
+    null |
     integer() |
     float() |
     binary() |
     atom() |
     list(input_term()) |
-    list({binary() | atom(), input_term()}) |
     #{ binary() | atom() => input_term() }.
 
 -type decode_error() ::

--- a/test/prop_thoas.erl
+++ b/test/prop_thoas.erl
@@ -1,0 +1,212 @@
+-module(prop_thoas).
+
+-export([
+         json_term/0, input_term/0
+]).
+
+-include_lib("proper/include/proper.hrl").
+%% -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+prop_decode_never_fails() ->
+    ?FORALL(
+       {Input, DecodeOpts},
+       {oneof([
+               ?LET(JsonStruct, json_term(), thoas:encode(JsonStruct)),
+               proper_unicode:utf8(),
+               binary(),
+               list(oneof([byte(), binary()]))
+              ]),
+        decode_options()},
+       case thoas:decode(Input, DecodeOpts) of
+           {ok, _} ->
+               true;
+           {error, _} ->
+               true;
+           Other ->
+               throw({unexpected_return, Other})
+       end).
+
+prop_valid_input_always_encodable() ->
+    ?FORALL(
+       {Input, EncOpts},
+       {json_term(), encode_options()},
+       begin
+           is_binary(thoas:encode(Input, EncOpts))
+       end).
+
+prop_encode_decode_matches() ->
+    ?FORALL(
+       {Input, EncOpts},
+       {json_term(), encode_options()},
+       begin
+           Encoded = thoas:encode(Input, EncOpts),
+           ?assertEqual({ok, Input}, thoas:decode(Encoded)),
+           true
+       end).
+
+prop_input_term_encodable_decodable() ->
+    ?FORALL(
+       {Input, EncOpts},
+       {input_term(), encode_options()},
+       begin
+           Encoded = thoas:encode(Input, EncOpts),
+           ?assertMatch({ok, _}, thoas:decode(Encoded)),
+           true
+       end).
+    
+
+prop_thoas_encode_jsx_decode_match() ->
+    ?FORALL(
+       Input,
+       json_term(),
+       begin
+           Encoded = thoas:encode(Input),
+           ?assertEqual(Input, jsx:decode(Encoded)),
+           true
+       end).
+
+prop_jsx_encode_thoas_decode_match() ->
+    ?FORALL(
+       Input,
+       json_term(),
+       begin
+           Encoded = jsx:encode(Input),
+           ?assertEqual({ok, Input}, thoas:decode(Encoded)),
+           true
+       end).
+
+%% Not realy reliable
+%% prop_encode_not_slower_than_jsx() ->
+%%     ?FORALL(
+%%        Input,
+%%        ?SIZED(Size, json_term(Size + 10)),
+%%        begin
+%%            erlang:garbage_collect(),
+%%            {JsxTime, _} = timer:tc(run_n_f(fun() -> jsx:encode(Input) end, 50)),
+%%            erlang:garbage_collect(),
+%%            {ThoasTime, _} = timer:tc(run_n_f(fun() -> thoas:encode(Input) end, 50)),
+%%            ?assert(ThoasTime / JsxTime < 2,
+%%                    [{thoas_time, ThoasTime},
+%%                     {jsx_time, JsxTime}]),
+%%            true
+%%        end).
+
+%% prop_decode_not_slower_than_jsx() ->
+%%     ?FORALL(
+%%        Input,
+%%        ?SIZED(Size, json_term(Size + 10)),
+%%        begin
+%%            JsonBin = thoas:encode(Input),
+%%            erlang:garbage_collect(),
+%%            {JsxTime, _} = timer:tc(run_n_f(fun() -> jsx:decode(JsonBin) end, 50)),
+%%            erlang:garbage_collect(),
+%%            {ThoasTime, _} = timer:tc(run_n_f(fun() -> thoas:decode(JsonBin) end, 50)),
+%%            ?assert(ThoasTime / JsxTime < 2,
+%%                    [{thoas_time, ThoasTime},
+%%                     {jsx_time, JsxTime}]),
+%%            true
+%%        end).
+
+%% run_n_f(Fun, N) ->
+%%     fun() -> run_n(Fun, N) end.
+
+%% run_n(_Fun, 0) -> ok;
+%% run_n(Fun, N) -> 
+%%     Fun(),
+%%     run_n(Fun, N - 1).
+
+%% Generator
+
+encode_options() ->
+    oneof(
+      [
+       #{},
+       ?LET(Escape,
+            oneof([json, unicode, html, javascript]),
+            #{escape => Escape})
+      ]).
+
+decode_options() ->
+    oneof(
+      [
+       #{},
+       ?LET(Strings,
+            oneof([reference, copy]),
+            #{strings => Strings})
+      ]).
+-define(DIV_FACTOR, 4).
+
+%% flexible representation (accepted by encoder, but can be altered by decoder)
+input_term() ->
+  ?SIZED(Size, input_term(Size)).
+
+input_term(Size) ->
+  ?LAZY(proper_types:frequency(
+          [{40, json_term(Size)},
+           {10, ?SUCHTHAT(Atom, atom(), not lists:member(Atom, [true, false, null]))},
+           {20, j_array(Size, fun input_term/1)},
+           {10, j_object(Size, fun input_term/1)},
+           {20, proplist_object(Size)}
+          ])).
+
+proplist_object(0) ->
+    #{};                                        %[] would be confused for array
+proplist_object(Size) ->
+    proper_types:list({proper_types:oneof([j_string(), atom()]),
+                       input_term(Size div ?DIV_FACTOR)}).
+
+%% Canonical representation (returned by decoder)
+json_term() ->
+  ?SIZED(Size, json_term(Size)).
+
+
+json_term(0) ->
+  j_literal();
+json_term(Size) ->
+  ?LAZY(proper_types:frequency(
+          [{50, j_literal()},
+           {25, j_array(Size)},
+           {25, j_object(Size)}])).
+
+j_object(Size) ->
+    j_object(Size, fun json_term/1).
+j_object(0, _) ->
+  #{};
+j_object(Size, Of) ->
+  ?LET(KV,
+       proper_types:list({j_string(), Of(Size div ?DIV_FACTOR)}),
+       maps:from_list(KV)).
+
+j_array(Size) ->
+    j_array(Size, fun json_term/1).
+j_array(0, _) ->
+  [];
+j_array(Size, Of) ->
+  proper_types:list(Of(Size div ?DIV_FACTOR)).
+
+j_string() ->
+    proper_types:oneof(
+      [alphanum(),
+       proper_unicode:utf8()]).
+
+
+j_literal() ->
+    proper_types:oneof(
+      [j_string(),
+       proper_types:integer(),
+       proper_types:float(),
+       proper_types:boolean(),
+       null]).
+
+alphanum() ->
+  %% proper_unicode:utf8().
+  ?LET(Str,
+       proper_types:non_empty(alphanum_str()),
+       unicode:characters_to_binary(Str)).
+
+alphanum_str() ->
+  proper_types:list(
+    proper_types:oneof(lists:seq($a, $z) ++
+                         lists:seq($A, $Z) ++
+                         lists:seq($0, $9))).

--- a/test/prop_thoas.erl
+++ b/test/prop_thoas.erl
@@ -1,11 +1,10 @@
 -module(prop_thoas).
 
 -export([
-         json_term/0, input_term/0
+    json_term/0, input_term/0
 ]).
 
 -include_lib("proper/include/proper.hrl").
-%% -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
 prop_decode_never_fails() ->
@@ -100,46 +99,6 @@ prop_jsx_encode_thoas_decode_match() ->
            true
        end).
 
-%% Not realy reliable
-%% prop_encode_not_slower_than_jsx() ->
-%%     ?FORALL(
-%%        Input,
-%%        ?SIZED(Size, json_term(Size + 10)),
-%%        begin
-%%            erlang:garbage_collect(),
-%%            {JsxTime, _} = timer:tc(run_n_f(fun() -> jsx:encode(Input) end, 50)),
-%%            erlang:garbage_collect(),
-%%            {ThoasTime, _} = timer:tc(run_n_f(fun() -> thoas:encode(Input) end, 50)),
-%%            ?assert(ThoasTime / JsxTime < 2,
-%%                    [{thoas_time, ThoasTime},
-%%                     {jsx_time, JsxTime}]),
-%%            true
-%%        end).
-
-%% prop_decode_not_slower_than_jsx() ->
-%%     ?FORALL(
-%%        Input,
-%%        ?SIZED(Size, json_term(Size + 10)),
-%%        begin
-%%            JsonBin = thoas:encode(Input),
-%%            erlang:garbage_collect(),
-%%            {JsxTime, _} = timer:tc(run_n_f(fun() -> jsx:decode(JsonBin) end, 50)),
-%%            erlang:garbage_collect(),
-%%            {ThoasTime, _} = timer:tc(run_n_f(fun() -> thoas:decode(JsonBin) end, 50)),
-%%            ?assert(ThoasTime / JsxTime < 2,
-%%                    [{thoas_time, ThoasTime},
-%%                     {jsx_time, JsxTime}]),
-%%            true
-%%        end).
-
-%% run_n_f(Fun, N) ->
-%%     fun() -> run_n(Fun, N) end.
-
-%% run_n(_Fun, 0) -> ok;
-%% run_n(Fun, N) -> 
-%%     Fun(),
-%%     run_n(Fun, N - 1).
-
 %% Generator
 
 encode_options() ->
@@ -159,55 +118,49 @@ decode_options() ->
             oneof([reference, copy]),
             #{strings => Strings})
       ]).
+
 -define(DIV_FACTOR, 4).
 
 %% flexible representation (accepted by encoder, but can be altered by decoder)
 input_term() ->
-  ?SIZED(Size, input_term(Size)).
+    ?SIZED(Size, input_term(Size)).
 
 input_term(Size) ->
-  ?LAZY(proper_types:frequency(
-          [{40, json_term(Size)},
-           {10, ?SUCHTHAT(Atom, atom(), not lists:member(Atom, [true, false, null]))},
-           {20, j_array(Size, fun input_term/1)},
-           {10, j_object(Size, fun input_term/1)},
-           {20, proplist_object(Size)}
-          ])).
-
-proplist_object(0) ->
-    #{};                                        %[] would be confused for array
-proplist_object(Size) ->
-    proper_types:list({proper_types:oneof([j_string(), atom()]),
-                       input_term(Size div ?DIV_FACTOR)}).
+    ?LAZY(proper_types:frequency(
+            [{40, json_term(Size)},
+             {20, ?SUCHTHAT(Atom, atom(), not lists:member(Atom, [true, false, null]))},
+             {20, j_array(Size, fun input_term/1)},
+             {20, j_object(Size, fun input_term/1)}
+            ])).
 
 %% Canonical representation (returned by decoder)
 json_term() ->
-  ?SIZED(Size, json_term(Size)).
+    ?SIZED(Size, json_term(Size)).
 
 
 json_term(0) ->
-  j_literal();
+    j_literal();
 json_term(Size) ->
-  ?LAZY(proper_types:frequency(
-          [{50, j_literal()},
-           {25, j_array(Size)},
-           {25, j_object(Size)}])).
+    ?LAZY(proper_types:frequency(
+            [{50, j_literal()},
+             {25, j_array(Size)},
+             {25, j_object(Size)}])).
 
 j_object(Size) ->
     j_object(Size, fun json_term/1).
 j_object(0, _) ->
-  #{};
+    #{};
 j_object(Size, Of) ->
-  ?LET(KV,
-       proper_types:list({j_string(), Of(Size div ?DIV_FACTOR)}),
-       maps:from_list(KV)).
+    ?LET(KV,
+         proper_types:list({j_string(), Of(Size div ?DIV_FACTOR)}),
+         maps:from_list(KV)).
 
 j_array(Size) ->
     j_array(Size, fun json_term/1).
 j_array(0, _) ->
-  [];
+    [];
 j_array(Size, Of) ->
-  proper_types:list(Of(Size div ?DIV_FACTOR)).
+    proper_types:list(Of(Size div ?DIV_FACTOR)).
 
 j_string() ->
     proper_types:oneof(
@@ -224,13 +177,13 @@ j_literal() ->
        null]).
 
 alphanum() ->
-  %% proper_unicode:utf8().
-  ?LET(Str,
-       proper_types:non_empty(alphanum_str()),
-       unicode:characters_to_binary(Str)).
+    %% proper_unicode:utf8().
+    ?LET(Str,
+         proper_types:non_empty(alphanum_str()),
+         unicode:characters_to_binary(Str)).
 
 alphanum_str() ->
-  proper_types:list(
-    proper_types:oneof(lists:seq($a, $z) ++
-                         lists:seq($A, $Z) ++
-                         lists:seq($0, $9))).
+    proper_types:list(
+      proper_types:oneof(lists:seq($a, $z) ++
+                             lists:seq($A, $Z) ++
+                             lists:seq($0, $9))).


### PR DESCRIPTION
Mostly based the generators on the typespecs in `thoas` module. Some of it borrowed from my old gist https://gist.github.com/seriyps/ffe0f5f5ba270fc4dd395208718e84d3

It fails on some input, CI would fail because of that:

* `escape => html` sometimes fails
* `[{K, V}]` representation of JSON objects seems to not be supported

Also I noticed typespec misses `null`