### PR TITLE
Allow optimization of binary matches in escapeu_1/8 and escapeu_2/8

### DIFF
--- a/src/thoas_decode.erl
+++ b/src/thoas_decode.erl
@@ -122,13 +122,13 @@ escape_surrogate(<<_Rest/bitstring>>, Input, Skip, _Stack, _StringDecode, _Acc, 
     throw_error(Input, Skip + 6).
 
 
-escapeu_1(Rest, Input, Skip, Stack, StringDecode, Acc, Last, X) ->
+escapeu_1(<<_/bitstring>> = Rest, Input, Skip, Stack, StringDecode, Acc, Last, X) ->
     A = 6 bsl 5 + (X bsl 2) + (Last bsr 6),
     B = 2 bsl 6 + Last band 63,
     C = [Acc, A, B],
     string(Rest, Input, Skip + 6, Stack, StringDecode, C, 0).
 
-escapeu_2(Rest, Input, Skip, Stack, StringDecode, Acc, Last, X) ->
+escapeu_2(<<_/bitstring>> = Rest, Input, Skip, Stack, StringDecode, Acc, Last, X) ->
     A = 14 bsl 4 + (X bsr 4),
     B = 2 bsl 6 + (X band 15 bsl 2) + (Last bsr 6),
     C = 2 bsl 6 + Last band 63,


### PR DESCRIPTION
This quiets the 'NOT OPTIMIZED' messages from the compilation
with binary optimization messages:

     ERL_COMPILER_OPTIONS=bin_opt_info rebar3 compile

The compiler doesn't have enough information in the body of
`escapeu_1/8` or `escapeu_2/8` to know that `Rest` will always
be a bitstring. We can tell it so in the parameter list with a
pattern match on any bitstring.

Although it doesn't appear to have a noticeable effect on speed
according to the benchmark.