### PR TITLE
Add `null` and boolean results to decoding results spec.

### DIFF
--- a/src/thoas.erl
+++ b/src/thoas.erl
@@ -22,6 +22,8 @@
     integer() |
     float() |
     binary() |
+    boolean() |
+    'null' |
     list(json_term()) |
     #{ binary() => json_term() }.
 


### PR DESCRIPTION
As this is what happens when called like `thoas:decode("true").`