### PR TITLE
Provide hex docs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,18 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
+
+{project_plugins, [rebar3_ex_doc, rebar3_hex]}.
+
+{hex, [{doc, #{provider => ex_doc}}]}.
+
+{ex_doc, [
+    {extras, [
+        {'CHANGELOG.md', #{title => <<"Changelog">>}},
+        {'README.md', #{title => <<"Overview">>}},
+        {'LICENSE', #{title => <<"License">>}}
+    ]},
+    {main, <<"readme">>},
+    {homepage_url, <<"https://github.com/lpil/thoas">>},
+    {source_url, <<"https://github.com/lpil/thoas">>},
+    {api_reference, false}
+]}.


### PR DESCRIPTION
There is no documentation visiting the [thoas hex page](https://hex.pm/packages/thoas).
This PR adds the config to provide this.
See more about in [rebar3_ex_doc docs](https://hexdocs.pm/rebar3_ex_doc/readme.html) and a more detailed version in the [ExDoc docs](https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html#module-configuration) (elixir version).